### PR TITLE
Fix text overlapping in chapter 3

### DIFF
--- a/js/chapters/E_Complex_Contagion.js
+++ b/js/chapters/E_Complex_Contagion.js
@@ -233,6 +233,7 @@ SLIDES.push(
 {
 	remove:[
 		{type:"box", id:"complex_cascade"},
+		{type:"box", id:"complex_cascade_feel_free"},
 		{type:"box", id:"end"}
 	],
 	move:[


### PR DESCRIPTION
In this scene of chapter 3
![image](https://user-images.githubusercontent.com/11247099/39635338-d014deae-4fef-11e8-8639-68b48f8d8fe6.png)

If you hit the `skip` button, the "feel free" text will not remove as excepted.

![image](https://user-images.githubusercontent.com/11247099/39635311-b73199f4-4fef-11e8-9095-3b1fd87ecdb6.png)

Here is the fixed version: https://rawgit.com/antfu/crowds/overlapping-fix/
