### PR TITLE
Improve the UX of translations switching

### DIFF
--- a/js/slideshow/Translations.js
+++ b/js/slideshow/Translations.js
@@ -2,11 +2,16 @@ window.TRANSLATIONS = [];
 window.ADD_YOUR_OWN_LINK = "https://github.com/ncase/crowds#how-to-translate-this-thing";
 
 var r = new XMLHttpRequest();
+var DEFAULT_LANG_CODE = 'en';
+
 r.open("GET", "translations.txt?cache="+Math.round(1000*Math.random()), true); // force cache refresh
 r.onreadystatechange = function () {
 	
 	if(r.readyState != 4 || r.status != 200) return;
 
+	// Get current language code from path
+	var currentCode = location.pathname.split('/').slice(-1)[0].replace('.html', '') || DEFAULT_LANG_CODE;
+	
 	// Parse available translations
 	// Only lines of the form "nn: name"
 	var response = r.responseText;
@@ -18,7 +23,7 @@ r.onreadystatechange = function () {
 		var a = available[i];
 		var code = a.match(/[a-z]{2}(?:-[A-Z]{2})?/)[0];
 		var lang = a.match(/^[a-z]{2}(?:-[A-Z]{2})?\:?\s+(.+)/)[1];
-		if(code=="en") continue; // English is just an example
+		if(code === currentCode) continue; // Hide current language tab
 		TRANSLATIONS.push({
 			code: code,
 			lang: lang
@@ -45,8 +50,10 @@ function _createLinks(separator){
 	var html = "";
 	for(var i=0; i<TRANSLATIONS.length; i++){
 		var t = TRANSLATIONS[i];
+		// Refer to root if the language is default (en)
+		var href = (t.code === DEFAULT_LANG_CODE) ? '.' : (t.code+".html");
 		if(i>0) html+=separator;
-		html += "<a href='"+t.code+".html' style='text-decoration:none'>";
+		html += "<a href='"+href+"' style='text-decoration:none'>";
 		html += t.lang;
 		html += "</a>";
 	}


### PR DESCRIPTION
This should fix #27.

This PR makes the translations list showing **languages without current language**(including English).

![image](https://user-images.githubusercontent.com/11247099/39666134-89b0baea-50d1-11e8-8d01-ec61f2e90d36.png)

Live: https://rawgit.com/antfu/crowds/translation-switch-improve/