### PR TITLE
Fix "original in English" href

### DIFF
--- a/es.html
+++ b/es.html
@@ -285,7 +285,7 @@ it should automatically highlight what the text is (usually in white).
 		<!-- TRANSLATE note: comment out the line below... -->
 		<!-- te llevará unos 30 min • creada por nicky case en abril de 2018 -->
 		<!-- ...and UN-comment + TRANSLATE this line! -->
-		creada por nicky case • traducida por swyter • <a href='/'>puedes verla en inglés</a>
+		creada por nicky case • traducida por swyter • <a href='.'>puedes verla en inglés</a>
 	</div>
 
 </words>

--- a/fr.html
+++ b/fr.html
@@ -285,7 +285,7 @@ it should automatically highlight what the text is (usually in white).
 		<!-- TRANSLATE note: comment out the line below... -->
 		<!-- Temps de jeu: 30 min • par nicky case, april 2018 -->
 		<!-- ...and UN-comment + TRANSLATE this line! -->
-		Par nicky case • Traduit par @clemkeirua • <a href='/'>original en anglais</a>
+		Par nicky case • Traduit par @clemkeirua • <a href='.'>original en anglais</a>
 	</div>
 
 </words>

--- a/index.html
+++ b/index.html
@@ -286,7 +286,7 @@ it should automatically highlight what the text is (usually in white).
 		<!-- TRANSLATE note: comment out the line below... -->
 		playing time: 30 min • by nicky case, april 2018
 		<!-- ...and UN-comment + TRANSLATE this line! -->
-		<!-- by nicky case • translated by [your name] • <a href='/'>original in English</a> -->
+		<!-- by nicky case • translated by [your name] • <a href='.'>original in English</a> -->
 	</div>
 
 </words>

--- a/it.html
+++ b/it.html
@@ -285,7 +285,7 @@ it should automatically highlight what the text is (usually in white).
 		<!-- TRANSLATE note: comment out the line below... 
 		playing time: 30 min • by nicky case, april 2018-->
 		<!-- ...and UN-comment + TRANSLATE this line! -->
-		di nicky case • versione italiana michele fenu • <a href='/'>original in English</a>
+		di nicky case • versione italiana michele fenu • <a href='.'>original in English</a>
 	</div>
 
 </words>

--- a/pt.html
+++ b/pt.html
@@ -285,7 +285,7 @@ it should automatically highlight what the text is (usually in white).
 		<!-- TRANSLATE note: comment out the line below... -->
 		<!-- playing time: 30 min • by nicky case, april 2018 -->
 		<!-- ...and UN-comment + TRANSLATE this line! -->
-		<small>por nicky case • traduzido por Italo Lelis e Iuri Rezende • <a href='/'>original in English</a></small>
+		<small>por nicky case • traduzido por Italo Lelis e Iuri Rezende • <a href='.'>original in English</a></small>
 	</div>
 
 </words>

--- a/ru.html
+++ b/ru.html
@@ -277,7 +277,7 @@ it should automatically highlight what the text is (usually in white).
     <!-- TRANSLATE note: comment out the line below... -->
     <!-- playing time: 30 min • by nicky case, april 2018 -->
     <!-- ...and UN-comment + TRANSLATE this line! -->
-    от nicky case • перевод <a href="https://toby3d.github.io">toby3d</a> • <a href='/'>original in English</a>
+    от nicky case • перевод <a href="https://toby3d.github.io">toby3d</a> • <a href='.'>original in English</a>
   </div>
 </words>
 

--- a/vi.html
+++ b/vi.html
@@ -285,7 +285,7 @@ it should automatically highlight what the text is (usually in white).
 		<!-- TRANSLATE note: comment out the line below... -->
 		thời gian chơi: 30 phút • 
 		<!-- ...and UN-comment + TRANSLATE this line! -->
-		by nicky case • translated by [Nghia Le] • <a href='/'>original in English</a>
+		by nicky case • translated by [Nghia Le] • <a href='.'>original in English</a>
 	</div>
 
 </words>


### PR DESCRIPTION
The original `href='/"` will refer to http://ncase.me instead of http://ncase.me/crowds/ as excepted.