### PR TITLE
Castillian Spanish (es-ES): Fix some borked meta tags, add correct lang attributes

### DIFF
--- a/es.html
+++ b/es.html
@@ -45,6 +45,7 @@ Good luck, and thanks again!
 	<meta content="utf-8" http-equiv="encoding">
 	<meta charset="utf-8">
 	<link rel="icon" type="image/png" href="favicon.png">
+	<link rel="alternate" href="http://ncase.me/crowds/" hreflang="en">
 
 	<!-- Sharing -->
 	<meta itemprop="name" content="La sabiduría y/o locura de las masas"> <!-- content="(TRANSLATE this part only)" -->
@@ -61,7 +62,7 @@ Good luck, and thanks again!
 	<meta property="og:title" content="La sabiduría y/o locura de las masas"> <!-- content="(TRANSLATE this part only)" -->
 	<meta property="og:description" content="una guía interactiva sobre las redes sociales humanas"> <!-- content="(TRANSLATE this part only)" -->
 	<meta property="og:type" content="website">
-	<meta property="og:url" content="http://ncase.me/crowds/">
+	<meta property="og:url" content="http://ncase.me/crowds/es.html">
 	<meta property="og:image" content="http://ncase.me/crowds/social/thumb.png">
 
 	<!-- Styles -->

--- a/es.html
+++ b/es.html
@@ -35,7 +35,7 @@ Good luck, and thanks again!
 -->
 
 <!DOCTYPE html>
-<html>
+<html lang="es-ES">
 <head>
 
 	<!-- Meta Info -->
@@ -51,14 +51,14 @@ Good luck, and thanks again!
 	<meta itemprop="description" content="una guía interactiva sobre las redes sociales humanas"> <!-- content="(TRANSLATE this part only)" -->
 	<meta itemprop="image" content="http://ncase.me/crowds/social/thumb.png">
 
-	<meta name="twitter:title" content="a sabiduría y/o locura de las masas"> <!-- content="(TRANSLATE this part only)" -->
+	<meta name="twitter:title" content="La sabiduría y/o locura de las masas"> <!-- content="(TRANSLATE this part only)" -->
 	<meta name="twitter:description" content="una guía interactiva sobre las redes sociales humanas"> <!-- content="(TRANSLATE this part only)" -->
 	<meta name="twitter:card" content="summary_large_image">
 	<meta name="twitter:site" content="@ncasenmare">
 	<meta name="twitter:creator" content="@ncasenmare">
 	<meta name="twitter:image" content="http://ncase.me/crowds/social/thumb.png">
 
-	<meta property="og:title" content="The Wisdom and/or Madness of Crowds"> <!-- content="(TRANSLATE this part only)" -->
+	<meta property="og:title" content="La sabiduría y/o locura de las masas"> <!-- content="(TRANSLATE this part only)" -->
 	<meta property="og:description" content="una guía interactiva sobre las redes sociales humanas"> <!-- content="(TRANSLATE this part only)" -->
 	<meta property="og:type" content="website">
 	<meta property="og:url" content="http://ncase.me/crowds/">

--- a/es.html
+++ b/es.html
@@ -357,7 +357,7 @@ Also, <b></b> bolds a word/phrase, and <i></i> italicizes a word/phrase.
 	<br>
 	de un huracán, o comunidades enteras creando soluciones a problemas
 	<br>
-	y luchando por un mundo mejor; ¡la sabiduría de las masas
+	y luchando por un mundo mejor; ¡la sabiduría de las masas!
 	<br><br>
 	<b>¿Pero <i>cómo</i> es que la gente puede elegir tan bien y mal a la vez?</b>
 	<br>
@@ -425,8 +425,8 @@ Also, <b></b> bolds a word/phrase, and <i></i> italicizes a word/phrase.
 	<div style="position:absolute; top:5px;">
 		¡notas <i>opcionales</i>! &uarr;
 	</div>
-	<div style="position:absolute; left:216px; top:10px;">
-		&darr; enlaces y referencias
+	<div style="position:absolute; left:230px; top:10px;">
+		enlaces y referencias &darr;
 	</div>
 </words>
 
@@ -436,7 +436,7 @@ Also, <b></b> bolds a word/phrase, and <i></i> italicizes a word/phrase.
 
 	<br>
 
-	Un caso muy práctico ocurrió en un estudio de 1991<ref id="drunk"></ref>, que decía que
+	Un caso muy práctico ocurrió en un estudio<ref id="drunk"></ref> de 1991, que decía que
 	«prácticamente todos los estudiantes [universitarios] pensaban que sus amigos le daban a la botella más que ellos».
 	¿Pero cómo es eso? ¡No puede ser!
 	Ya verás, estás a punto de descubrirlo por tu cuenta y riesgo dibujando redes sociales.
@@ -664,7 +664,7 @@ Also, <b></b> bolds a word/phrase, and <i></i> italicizes a word/phrase.
 <words id="complex_groupthink">
 		
 	Los de la NASA son unos listillos.
-	Después de todo utilizan las ecuaciones de Newton para llevarnos a la Luna.
+	Después de todo utilizan las ecuaciones de Newton para llevarnos a la luna.
 	Pero bueno, resumiendo un poco, en 1986,
 	<i>incluso después de desoír las advertencias de los ingenieros</i>,
 	lanzaron el <i>Challenger</i>,


### PR DESCRIPTION
I swear I translated this at some point. :)
* Add a `lang=es-ES` attribute to the root `<html>` element, so that search engines can pick the correct version.
* Add a `<link rel="alternate">` to let search engines know the original variant.
* Fix the OpenGraph/Facebook `og:url` tag.


By the way, @ncase. Take a look here: https://support.google.com/webmasters/answer/189077?hl=en