### PR TITLE
i18n: Use lang attribute in each root <html> element + alternate versions

### DIFF
--- a/fr.html
+++ b/fr.html
@@ -35,16 +35,28 @@ Good luck, and thanks again!
 -->
 
 <!DOCTYPE html>
-<html>
+<html lang="fr"> <!-- lang="(TRANSLATE: set your language code here, same as the page name!) e.g: es, es-ES, pt-BR, ja, it, fr-CA, de, ..." -->
 <head>
 
 	<!-- Meta Info -->
 	<title>La sagesse et/ou folie des foules</title> <!-- <title>(TRANSLATE this part only)</title> -->
 	<meta name="description" content="un guide interactif des réseaux humains"/> <!-- content="(TRANSLATE this part only)" -->
-    <meta content="text/html;charset=utf-8" http-equiv="Content-Type">
+	<meta content="text/html;charset=utf-8" http-equiv="Content-Type">
 	<meta content="utf-8" http-equiv="encoding">
 	<meta charset="utf-8">
 	<link rel="icon" type="image/png" href="favicon.png">
+
+	<link rel="alternate" href="http://ncase.me/crowds/"           hreflang="en">
+	<link rel="alternate" href="http://ncase.me/crowds/es.html"    hreflang="es-ES">
+	<link rel="alternate" href="http://ncase.me/crowds/fr.html"    hreflang="fr">
+	<link rel="alternate" href="http://ncase.me/crowds/it.html"    hreflang="it">
+	<link rel="alternate" href="http://ncase.me/crowds/ja.html"    hreflang="ja">
+	<link rel="alternate" href="http://ncase.me/crowds/pt.html"    hreflang="pt">
+	<link rel="alternate" href="http://ncase.me/crowds/ru.html"    hreflang="ru">
+	<link rel="alternate" href="http://ncase.me/crowds/uk.html"    hreflang="uk">
+	<link rel="alternate" href="http://ncase.me/crowds/vi.html"    hreflang="vi">
+	<link rel="alternate" href="http://ncase.me/crowds/zh-CN.html" hreflang="zh-CN">
+	<link rel="alternate" href="http://ncase.me/crowds/zh-TW.html" hreflang="zh-TW">
 
 	<!-- Sharing -->
 	<meta itemprop="name" content="La sagesse et/ou folie des foules"> <!-- content="(TRANSLATE this part only)" -->

--- a/index.html
+++ b/index.html
@@ -35,16 +35,28 @@ Good luck, and thanks again!
 -->
 
 <!DOCTYPE html>
-<html>
+<html lang="en"> <!-- lang="(TRANSLATE: set your language code here, same as the page name!) e.g: es, es-ES, pt-BR, ja, it, fr-CA, de, ..." -->
 <head>
 
 	<!-- Meta Info -->
 	<title>The Wisdom and/or Madness of Crowds</title> <!-- <title>(TRANSLATE this part only)</title> -->
 	<meta name="description" content="an interactive guide to human networks"/> <!-- content="(TRANSLATE this part only)" -->
-    <meta content="text/html;charset=utf-8" http-equiv="Content-Type">
+	<meta content="text/html;charset=utf-8" http-equiv="Content-Type">
 	<meta content="utf-8" http-equiv="encoding">
 	<meta charset="utf-8">
 	<link rel="icon" type="image/png" href="favicon.png">
+
+	<link rel="alternate" href="http://ncase.me/crowds/"           hreflang="en">
+	<link rel="alternate" href="http://ncase.me/crowds/es.html"    hreflang="es-ES">
+	<link rel="alternate" href="http://ncase.me/crowds/fr.html"    hreflang="fr">
+	<link rel="alternate" href="http://ncase.me/crowds/it.html"    hreflang="it">
+	<link rel="alternate" href="http://ncase.me/crowds/ja.html"    hreflang="ja">
+	<link rel="alternate" href="http://ncase.me/crowds/pt.html"    hreflang="pt">
+	<link rel="alternate" href="http://ncase.me/crowds/ru.html"    hreflang="ru">
+	<link rel="alternate" href="http://ncase.me/crowds/uk.html"    hreflang="uk">
+	<link rel="alternate" href="http://ncase.me/crowds/vi.html"    hreflang="vi">
+	<link rel="alternate" href="http://ncase.me/crowds/zh-CN.html" hreflang="zh-CN">
+	<link rel="alternate" href="http://ncase.me/crowds/zh-TW.html" hreflang="zh-TW">
 
 	<!-- Sharing -->
 	<meta itemprop="name" content="The Wisdom and/or Madness of Crowds"> <!-- content="(TRANSLATE this part only)" -->

--- a/it.html
+++ b/it.html
@@ -35,16 +35,28 @@ Good luck, and thanks again!
 -->
 
 <!DOCTYPE html>
-<html>
+<html lang="it"> <!-- lang="(TRANSLATE: set your language code here, same as the page name!) e.g: es, es-ES, pt-BR, ja, it, fr-CA, de, ..." -->
 <head>
 
 	<!-- Meta Info -->
 	<title>La saggezza e la follia delle masse</title> <!-- <title>(TRANSLATED)</title> -->
 	<meta name="description" content="una guida interattiva alle reti sociali"/> <!-- content="(TRANSLATED)" -->
-    <meta content="text/html;charset=utf-8" http-equiv="Content-Type">
+	<meta content="text/html;charset=utf-8" http-equiv="Content-Type">
 	<meta content="utf-8" http-equiv="encoding">
 	<meta charset="utf-8">
 	<link rel="icon" type="image/png" href="favicon.png">
+
+	<link rel="alternate" href="http://ncase.me/crowds/"           hreflang="en">
+	<link rel="alternate" href="http://ncase.me/crowds/es.html"    hreflang="es-ES">
+	<link rel="alternate" href="http://ncase.me/crowds/fr.html"    hreflang="fr">
+	<link rel="alternate" href="http://ncase.me/crowds/it.html"    hreflang="it">
+	<link rel="alternate" href="http://ncase.me/crowds/ja.html"    hreflang="ja">
+	<link rel="alternate" href="http://ncase.me/crowds/pt.html"    hreflang="pt">
+	<link rel="alternate" href="http://ncase.me/crowds/ru.html"    hreflang="ru">
+	<link rel="alternate" href="http://ncase.me/crowds/uk.html"    hreflang="uk">
+	<link rel="alternate" href="http://ncase.me/crowds/vi.html"    hreflang="vi">
+	<link rel="alternate" href="http://ncase.me/crowds/zh-CN.html" hreflang="zh-CN">
+	<link rel="alternate" href="http://ncase.me/crowds/zh-TW.html" hreflang="zh-TW">
 
 	<!-- Sharing -->
 	<meta itemprop="name" content="La saggezza e la follia delle masse"> <!-- content="(TRANSLATED)" -->

--- a/ja.html
+++ b/ja.html
@@ -35,16 +35,28 @@ Good luck, and thanks again!
 -->
 
 <!DOCTYPE html>
-<html>
+<html lang="ja"> <!-- lang="(TRANSLATE: set your language code here, same as the page name!) e.g: es, es-ES, pt-BR, ja, it, fr-CA, de, ..." -->
 <head>
 
 	<!-- Meta Info -->
 	<title>群衆の英知もしくは狂気</title> <!-- <title>(TRANSLATE this part only)</title> -->
 	<meta name="description" content="人のつながりに関するインタラクティブなガイド"/> <!-- content="(TRANSLATE this part only)" -->
-    <meta content="text/html;charset=utf-8" http-equiv="Content-Type">
+	<meta content="text/html;charset=utf-8" http-equiv="Content-Type">
 	<meta content="utf-8" http-equiv="encoding">
 	<meta charset="utf-8">
 	<link rel="icon" type="image/png" href="favicon.png">
+
+	<link rel="alternate" href="http://ncase.me/crowds/"           hreflang="en">
+	<link rel="alternate" href="http://ncase.me/crowds/es.html"    hreflang="es-ES">
+	<link rel="alternate" href="http://ncase.me/crowds/fr.html"    hreflang="fr">
+	<link rel="alternate" href="http://ncase.me/crowds/it.html"    hreflang="it">
+	<link rel="alternate" href="http://ncase.me/crowds/ja.html"    hreflang="ja">
+	<link rel="alternate" href="http://ncase.me/crowds/pt.html"    hreflang="pt">
+	<link rel="alternate" href="http://ncase.me/crowds/ru.html"    hreflang="ru">
+	<link rel="alternate" href="http://ncase.me/crowds/uk.html"    hreflang="uk">
+	<link rel="alternate" href="http://ncase.me/crowds/vi.html"    hreflang="vi">
+	<link rel="alternate" href="http://ncase.me/crowds/zh-CN.html" hreflang="zh-CN">
+	<link rel="alternate" href="http://ncase.me/crowds/zh-TW.html" hreflang="zh-TW">
 
 	<!-- Sharing -->
 	<meta itemprop="name" content="群衆の英知もしくは狂気"> <!-- content="(TRANSLATE this part only)" -->

--- a/pt.html
+++ b/pt.html
@@ -35,16 +35,28 @@ Good luck, and thanks again!
 -->
 
 <!DOCTYPE html>
-<html>
+<html lang="pt"> <!-- lang="(TRANSLATE: set your language code here, same as the page name!) e.g: es, es-ES, pt-BR, ja, it, fr-CA, de, ..." -->
 <head>
 
 	<!-- Meta Info -->
 	<title>A Sabedoria e/ou Loucura das Multidões</title> <!-- <title>(TRANSLATE this part only)</title> -->
 	<meta name="description" content="um guia interativo das relações humanas"/> <!-- content="(TRANSLATE this part only)" -->
-    <meta content="text/html;charset=utf-8" http-equiv="Content-Type">
+	<meta content="text/html;charset=utf-8" http-equiv="Content-Type">
 	<meta content="utf-8" http-equiv="encoding">
 	<meta charset="utf-8">
 	<link rel="icon" type="image/png" href="favicon.png">
+
+	<link rel="alternate" href="http://ncase.me/crowds/"           hreflang="en">
+	<link rel="alternate" href="http://ncase.me/crowds/es.html"    hreflang="es-ES">
+	<link rel="alternate" href="http://ncase.me/crowds/fr.html"    hreflang="fr">
+	<link rel="alternate" href="http://ncase.me/crowds/it.html"    hreflang="it">
+	<link rel="alternate" href="http://ncase.me/crowds/ja.html"    hreflang="ja">
+	<link rel="alternate" href="http://ncase.me/crowds/pt.html"    hreflang="pt">
+	<link rel="alternate" href="http://ncase.me/crowds/ru.html"    hreflang="ru">
+	<link rel="alternate" href="http://ncase.me/crowds/uk.html"    hreflang="uk">
+	<link rel="alternate" href="http://ncase.me/crowds/vi.html"    hreflang="vi">
+	<link rel="alternate" href="http://ncase.me/crowds/zh-CN.html" hreflang="zh-CN">
+	<link rel="alternate" href="http://ncase.me/crowds/zh-TW.html" hreflang="zh-TW">
 
 	<!-- Sharing -->
 	<meta itemprop="name" content="A Sabedoria e/ou Loucura das Multidões"> <!-- content="(TRANSLATE this part only)" -->

--- a/ru.html
+++ b/ru.html
@@ -35,7 +35,7 @@ Good luck, and thanks again!
 -->
 
 <!DOCTYPE html>
-<html>
+<html lang="ru"> <!-- lang="(TRANSLATE: set your language code here, same as the page name!) e.g: es, es-ES, pt-BR, ja, it, fr-CA, de, ..." -->
 <head>
   <!-- Meta Info -->
   <title>Мудрость и/или безумие толп</title> <!-- <title>(TRANSLATE this part only)</title> -->
@@ -44,6 +44,18 @@ Good luck, and thanks again!
   <meta content="utf-8" http-equiv="encoding">
   <meta charset="utf-8">
   <link rel="icon" type="image/png" href="favicon.png">
+  
+  <link rel="alternate" href="http://ncase.me/crowds/"           hreflang="en">
+  <link rel="alternate" href="http://ncase.me/crowds/es.html"    hreflang="es-ES">
+  <link rel="alternate" href="http://ncase.me/crowds/fr.html"    hreflang="fr">
+  <link rel="alternate" href="http://ncase.me/crowds/it.html"    hreflang="it">
+  <link rel="alternate" href="http://ncase.me/crowds/ja.html"    hreflang="ja">
+  <link rel="alternate" href="http://ncase.me/crowds/pt.html"    hreflang="pt">
+  <link rel="alternate" href="http://ncase.me/crowds/ru.html"    hreflang="ru">
+  <link rel="alternate" href="http://ncase.me/crowds/uk.html"    hreflang="uk">
+  <link rel="alternate" href="http://ncase.me/crowds/vi.html"    hreflang="vi">
+  <link rel="alternate" href="http://ncase.me/crowds/zh-CN.html" hreflang="zh-CN">
+  <link rel="alternate" href="http://ncase.me/crowds/zh-TW.html" hreflang="zh-TW">
 
   <!-- Sharing -->
   <meta itemprop="name" content="Мудрость и/или безумие толп"> <!-- content="(TRANSLATE this part only)" -->

--- a/uk.html
+++ b/uk.html
@@ -35,16 +35,28 @@ Good luck, and thanks again!
 -->
 
 <!DOCTYPE html>
-<html>
+<html lang="uk"> <!-- lang="(TRANSLATE: set your language code here, same as the page name!) e.g: es, es-ES, pt-BR, ja, it, fr-CA, de, ..." -->
 <head>
 
 	<!-- Meta Info -->
 	<title>Мудрість та/або Безумство юрби</title> <!-- <title>(TRANSLATE this part only)</title> -->
 	<meta name="description" content="інтерактивний посібник з людських мереж"/> <!-- content="(TRANSLATE this part only)" -->
-    <meta content="text/html;charset=utf-8" http-equiv="Content-Type">
+	<meta content="text/html;charset=utf-8" http-equiv="Content-Type">
 	<meta content="utf-8" http-equiv="encoding">
 	<meta charset="utf-8">
 	<link rel="icon" type="image/png" href="favicon.png">
+
+	<link rel="alternate" href="http://ncase.me/crowds/"           hreflang="en">
+	<link rel="alternate" href="http://ncase.me/crowds/es.html"    hreflang="es-ES">
+	<link rel="alternate" href="http://ncase.me/crowds/fr.html"    hreflang="fr">
+	<link rel="alternate" href="http://ncase.me/crowds/it.html"    hreflang="it">
+	<link rel="alternate" href="http://ncase.me/crowds/ja.html"    hreflang="ja">
+	<link rel="alternate" href="http://ncase.me/crowds/pt.html"    hreflang="pt">
+	<link rel="alternate" href="http://ncase.me/crowds/ru.html"    hreflang="ru">
+	<link rel="alternate" href="http://ncase.me/crowds/uk.html"    hreflang="uk">
+	<link rel="alternate" href="http://ncase.me/crowds/vi.html"    hreflang="vi">
+	<link rel="alternate" href="http://ncase.me/crowds/zh-CN.html" hreflang="zh-CN">
+	<link rel="alternate" href="http://ncase.me/crowds/zh-TW.html" hreflang="zh-TW">
 
 	<!-- Sharing -->
 	<meta itemprop="name" content="Мудрість та/або Безумство юрби"> <!-- content="(TRANSLATE this part only)" -->

--- a/vi.html
+++ b/vi.html
@@ -35,16 +35,28 @@ Good luck, and thanks again!
 -->
 
 <!DOCTYPE html>
-<html>
+<html lang="vi"> <!-- lang="(TRANSLATE: set your language code here, same as the page name!) e.g: es, es-ES, pt-BR, ja, it, fr-CA, de, ..." -->
 <head>
 
 	<!-- Meta Info -->
 	<title>Sự khôn ngoan và/hay sự điên cuồng của đám đông</title> <!-- <title>(TRANSLATE this part only)</title> -->
 	<meta name="description" content="Một trò chơi tương tác giải thích về mạng lưới xã hội của con người"/> <!-- content="(TRANSLATE this part only)" -->
-    <meta content="text/html;charset=utf-8" http-equiv="Content-Type">
+	<meta content="text/html;charset=utf-8" http-equiv="Content-Type">
 	<meta content="utf-8" http-equiv="encoding">
 	<meta charset="utf-8">
 	<link rel="icon" type="image/png" href="favicon.png">
+
+	<link rel="alternate" href="http://ncase.me/crowds/"           hreflang="en">
+	<link rel="alternate" href="http://ncase.me/crowds/es.html"    hreflang="es-ES">
+	<link rel="alternate" href="http://ncase.me/crowds/fr.html"    hreflang="fr">
+	<link rel="alternate" href="http://ncase.me/crowds/it.html"    hreflang="it">
+	<link rel="alternate" href="http://ncase.me/crowds/ja.html"    hreflang="ja">
+	<link rel="alternate" href="http://ncase.me/crowds/pt.html"    hreflang="pt">
+	<link rel="alternate" href="http://ncase.me/crowds/ru.html"    hreflang="ru">
+	<link rel="alternate" href="http://ncase.me/crowds/uk.html"    hreflang="uk">
+	<link rel="alternate" href="http://ncase.me/crowds/vi.html"    hreflang="vi">
+	<link rel="alternate" href="http://ncase.me/crowds/zh-CN.html" hreflang="zh-CN">
+	<link rel="alternate" href="http://ncase.me/crowds/zh-TW.html" hreflang="zh-TW">
 
 	<!-- Sharing -->
 	<meta itemprop="name" content="Sự khôn ngoan và/hay sự điên cuồng của đám đông"> <!-- content="(TRANSLATE this part only)" -->

--- a/zh-CN.html
+++ b/zh-CN.html
@@ -35,7 +35,7 @@ Good luck, and thanks again!
 -->
 
 <!DOCTYPE html>
-<html lang="zh-CN">
+<html lang="zh-CN"> <!-- lang="(TRANSLATE: set your language code here, same as the page name!) e.g: es, es-ES, pt-BR, ja, it, fr-CA, de, ..." -->
 <head>
 
 	<!-- Meta Info -->
@@ -45,6 +45,18 @@ Good luck, and thanks again!
 	<meta content="utf-8" http-equiv="encoding">
 	<meta charset="utf-8">
 	<link rel="icon" type="image/png" href="favicon.png">
+
+	<link rel="alternate" href="http://ncase.me/crowds/"           hreflang="en">
+	<link rel="alternate" href="http://ncase.me/crowds/es.html"    hreflang="es-ES">
+	<link rel="alternate" href="http://ncase.me/crowds/fr.html"    hreflang="fr">
+	<link rel="alternate" href="http://ncase.me/crowds/it.html"    hreflang="it">
+	<link rel="alternate" href="http://ncase.me/crowds/ja.html"    hreflang="ja">
+	<link rel="alternate" href="http://ncase.me/crowds/pt.html"    hreflang="pt">
+	<link rel="alternate" href="http://ncase.me/crowds/ru.html"    hreflang="ru">
+	<link rel="alternate" href="http://ncase.me/crowds/uk.html"    hreflang="uk">
+	<link rel="alternate" href="http://ncase.me/crowds/vi.html"    hreflang="vi">
+	<link rel="alternate" href="http://ncase.me/crowds/zh-CN.html" hreflang="zh-CN">
+	<link rel="alternate" href="http://ncase.me/crowds/zh-TW.html" hreflang="zh-TW">
 
 	<!-- Sharing -->
 	<meta itemprop="name" content="群体的智慧与愚蠢"> <!-- content="(TRANSLATE this part only)" -->

--- a/zh-TW.html
+++ b/zh-TW.html
@@ -35,16 +35,28 @@ Good luck, and thanks again!
 -->
 
 <!DOCTYPE html>
-<html lang="zh-TW">
+<html lang="zh-TW"> <!-- lang="(TRANSLATE: set your language code here, same as the page name!) e.g: es, es-ES, pt-BR, ja, it, fr-CA, de, ..." -->
 <head>
 
 	<!-- Meta Info -->
 	<title>群眾的智慧與瘋狂</title> <!-- <title>(TRANSLATE this part only)</title> -->
 	<meta name="description" content="互動式講解人際網絡"/> <!-- content="(TRANSLATE this part only)" -->
-    <meta content="text/html;charset=utf-8" http-equiv="Content-Type">
+	<meta content="text/html;charset=utf-8" http-equiv="Content-Type">
 	<meta content="utf-8" http-equiv="encoding">
 	<meta charset="utf-8">
 	<link rel="icon" type="image/png" href="favicon.png">
+
+	<link rel="alternate" href="http://ncase.me/crowds/"           hreflang="en">
+	<link rel="alternate" href="http://ncase.me/crowds/es.html"    hreflang="es-ES">
+	<link rel="alternate" href="http://ncase.me/crowds/fr.html"    hreflang="fr">
+	<link rel="alternate" href="http://ncase.me/crowds/it.html"    hreflang="it">
+	<link rel="alternate" href="http://ncase.me/crowds/ja.html"    hreflang="ja">
+	<link rel="alternate" href="http://ncase.me/crowds/pt.html"    hreflang="pt">
+	<link rel="alternate" href="http://ncase.me/crowds/ru.html"    hreflang="ru">
+	<link rel="alternate" href="http://ncase.me/crowds/uk.html"    hreflang="uk">
+	<link rel="alternate" href="http://ncase.me/crowds/vi.html"    hreflang="vi">
+	<link rel="alternate" href="http://ncase.me/crowds/zh-CN.html" hreflang="zh-CN">
+	<link rel="alternate" href="http://ncase.me/crowds/zh-TW.html" hreflang="zh-TW">
 
 	<!-- Sharing -->
 	<meta itemprop="name" content="The Wisdom and/or Madness of Crowds"> <!-- content="(TRANSLATE this part only)" -->


### PR DESCRIPTION
Use a `lang` attribute in each root `<html>` element so that search engines and user agents know what language we are displaying.

Also, link to the alternate versions with `<link rel=alternate href=http://something hreflang=en>` so that they can point to the right counterpart.