### PR TITLE
Fix mistranslation of "diversity without division"

### DIFF
--- a/zh-TW.html
+++ b/zh-TW.html
@@ -753,7 +753,7 @@ Also, <b></b> bolds a word/phrase, and <i></i> italicizes a word/phrase.
 </words>
 <words id="bb_small_world_1">
 
-	<i>“統一但又不統一”。“具有多樣性卻又不具差異”。“E Pluribus Unum（拉丁語）: 合眾為一”</i>
+	<i>“和而不同”。“多元但不分裂”。“E Pluribus Unum（拉丁語）: 合眾為一”</i>
 	<br>
 	不管用何種方式表達，不同時代和文化的人們通常會得到同樣的智慧:
 	<b>


### PR DESCRIPTION
Before the translation it literally translated as "unification without unification" and "diversity without difference"