### PR TITLE
add abrevation period to et al.

### DIFF
--- a/index.html
+++ b/index.html
@@ -1295,7 +1295,7 @@ Final thing! These references also need you to TRANSLATE:
 
 	<div>
 	<a target="_blank" href="https://www.ncbi.nlm.nih.gov/pubmed/1758185">
-	“Biases in the perception of drinking norms among college students”</a> by Baer et al (1991)
+	“Biases in the perception of drinking norms among college students”</a> by Baer et al. (1991)
 	</div>
 
 </reference>
@@ -1307,7 +1307,7 @@ Final thing! These references also need you to TRANSLATE:
 
 	<div>
 	<a target="_blank" href="http://journals.plos.org/plosone/article?id=10.1371/journal.pone.0147617">
-	“The Majority Illusion in Social Networks”</a> by Lerman et al (2016).
+	“The Majority Illusion in Social Networks”</a> by Lerman et al. (2016).
 	<br>
 	Related: <a target="_blank" href="https://en.wikipedia.org/wiki/Friendship_paradox">
 	The Friendship Paradox</a>.
@@ -1339,7 +1339,7 @@ Final thing! These references also need you to TRANSLATE:
 	<div>
 	<a target="_blank" href="http://www.jstor.org/stable/42000514?seq=4#page_scan_tab_contents">
 	“Suicide Contagion and the Reporting of Suicide: Recommendations from a National Workshop”</a>
-	by O'Carroll et al (1994), endorsed by the frickin' Centers for Disease Control &amp; Prevention (CDC).
+	by O'Carroll et al. (1994), endorsed by the frickin' Centers for Disease Control &amp; Prevention (CDC).
 	</div>
 
 </reference>
@@ -1352,7 +1352,7 @@ Final thing! These references also need you to TRANSLATE:
 	<div>
 
 	<a target="_blank" href="http://journals.plos.org/plosone/article?id=10.1371/journal.pone.0117259">
-	“Contagion in Mass Killings and School Shootings”</a> by Towers et al (2015).
+	“Contagion in Mass Killings and School Shootings”</a> by Towers et al. (2015).
 
 	<br><br>
 


### PR DESCRIPTION
Since [`et al.` is an abbrevation](https://en.wikipedia.org/wiki/List_of_Latin_phrases_(E)#et_alii), there should be a period after the `al.`. Feel free to reject this PR, if you are following a style where you don't put the period (as apparently is the case with the AMA style as Wikipedia tells me).