### PR TITLE
fix mistranslation and typo in chapter 5, plus minor fixes

### DIFF
--- a/ja.html
+++ b/ja.html
@@ -762,13 +762,13 @@ Also, <b></b> bolds a word/phrase, and <i></i> italicizes a word/phrase.
 </words>
 <words id="bb_small_world_5">
 	
-	ネットワークの研究者たちは、この古代の英知の数学的な定義を知っている: 
-	<b>スモールネットワーク</b><ref id="small_world"></ref>だ。
-	結合と橋渡しのこの最適な混ざり合いは、
-	どうやってわれわれのニューロン<ref id="swn_neurons"></ref>がつながるか、
-	どうやって集合的創造性をどう育む<ref id="swn_creativity"></ref>か、
-	どうやって問題を解く<ref id="swn_social_physics"></ref>か、
-	そしてアメリカ合衆国大統領ジョン・F・ケネディが(なんとか)核戦争<ref id="swn_jfk"></ref>をどうやって回避したのかさえ説明できる！
+	ネットワークの研究者たちは、この古代の英知の数学的な定義を持っている:
+	<b>スモールワールドネットワーク</b><ref id="small_world"></ref>だ。
+	結合と橋渡しのこの最適な調和は、
+	どうやってわれわれのニューロン<ref id="swn_neurons"></ref>がつながるかを説明し、
+	集団的な創造性を育み<ref id="swn_creativity"></ref>、
+	集団的な問題解決を促進し<ref id="swn_social_physics"></ref>、
+	そしてアメリカ合衆国大統領ジョン・F・ケネディが(なんとか)核戦争<ref id="swn_jfk"></ref>を回避する助けにもなったんだ！
 	ということで、スモールワールドっていうのはすごいんだ。
 
 </words>
@@ -1458,15 +1458,15 @@ Final thing! These references also need you to TRANSLATE:
 <reference id="swn_creativity">
 
 	<h3>
-	“[スモールワールドネットワーク] は集合的創造性を育む”
+	“[スモールワールドネットワーク] は集団的な創造性を生む”
 	</h3>
 
 	<div>
 
 	<a target="_blank" href="http://www.jstor.org/stable/10.1086/432782?seq=1#page_scan_tab_contents">
 	“Collaboration and Creativity: The Small World Problem”</a> Uzzi と Spiro (2005).
-	この論文は、幾年にもわたるブロードウェイの社会的ネットワークについて解析し、
-	ネットワークは"スモールネットワーク"であるときに最もクリエイティブになることを発見した！
+	この論文は、何十年にもわたりブロードウェイの社会的ネットワークについて解析し、
+	ネットワークが"スモールワールド"ネットワークであるときに最もクリエイティブになることを発見した！
 
 	</div>
 
@@ -1474,7 +1474,7 @@ Final thing! These references also need you to TRANSLATE:
 <reference id="swn_social_physics">
 
 	<h3>
-	“[スモールワールドネットワーク] 集団的な問題解決能力を向上させる”
+	“[スモールワールドネットワーク] は集団的な問題解決を引き起こす”
 	</h3>
 
 	<div>

--- a/ja.html
+++ b/ja.html
@@ -942,7 +942,7 @@ Also, <b></b> bolds a word/phrase, and <i></i> italicizes a word/phrase.
 	<br>
 	<span style="position:relative; top:5px">~</span> Neil Gaiman &amp; Terry Pratchett
 	<div style="height:0.8em"></div>
-	<next small>&lt;3</next>
+	<next small>&hearts;</next>
 </words>
 
 <!-- Credits --> 

--- a/ja.html
+++ b/ja.html
@@ -419,7 +419,7 @@ Also, <b></b> bolds a word/phrase, and <i></i> italicizes a word/phrase.
 <words id="networks_pre_puzzle">
 	しかし、つながりは人々を<i>愚か</i>にもする。
 	地上にいるから地球が平らに見えているのと同じように、
-	そのつながりの<i>中に<i>にいる人々は社会について間違った考えに陥るかもしれない。
+	そのつながりの<i>中に</i>にいる人々は社会について間違った考えに陥るかもしれない。
 </words>
 
 <br><br>
@@ -1553,7 +1553,7 @@ Final thing! These references also need you to TRANSLATE:
 	“常識的な概念に懐疑的になれ”
 	</h3>
 	<div>
-	もちろん、<i>この</>注釈も含まれている。
+	もちろん、<i>この</i>注釈も含まれている。
 	</div>
 </reference>
 <reference id="sandbox">


### PR DESCRIPTION
The major fix is about the listing of the small world network features.
It's read as, the mix describes (all of four):

- how our neurons connect
- how to foster collective creativity
- how to solve problems
- how JFK avoided nuclear war

but that's probably not what's meant originally, (notably the third didn't make sense.)
So this rephrases to mean, the mix:

- describes how our neurons connect
- fosters collective creativity
- fosters collective problem-solving
- helped JFK avoid nuclear war

Please review if this parallelism matches the original sentence.
(I tried to maintain the good nuance of friendly expressions the first ja translator made, that may not be perfect though.)