### PR TITLE
Korean translation: 패트론->Patreon

### DIFF
--- a/ko.html
+++ b/ko.html
@@ -1025,7 +1025,7 @@ Also, <b></b> bolds a word/phrase, and <i></i> italicizes a word/phrase.
 		<span style="color:#777; position:relative; top:5px; display: inline-block; margin-top: 15px;">
 			많은 사랑과 감사를 보냅니다</span>
 		<div style="font-size: 3em; line-height: 1.0em;">
-			저의 패트론 후원자들</div>
+			저의 Patreon 후원자들</div>
 		<a target="_blank" href="https://www.patreon.com/ncase" style="text-decoration:none">
 			제가 더 많은 이런 것들을 만들게 도와주세요! &lt;3</a>
 		<br>


### PR DESCRIPTION
'패트론' is a pronunciation for "patron" rather than "Patreon". This is a name of an unfamiliar foreign service (for Koreans) so better to keep it English.